### PR TITLE
Mount gdrive and backup mysql tables to it

### DIFF
--- a/audino/docker-compose.dev.yml
+++ b/audino/docker-compose.dev.yml
@@ -44,6 +44,7 @@ services:
     volumes:
       - ./mysql:/mysql
       - mysql_data:/var/lib/mysql
+      - ./rclone/data:/mnt/backup
     environment:
       MYSQL_DATABASE: "audino"
       MYSQL_ROOT_PASSWORD: "root"
@@ -62,12 +63,13 @@ services:
       REDIS_PASSWORD: "audino"
     ports:
       - 6379:6379
+    depends_on:
+      - rclone
     networks:
       - backend-network
       
   rclone:
     image: rclone/rclone:latest
-    user: ${CURRENT_UID}
     volumes:
       - './rclone/config:/config/rclone'
       - './rclone/data:/mnt/data:shared'

--- a/audino/docker-compose.dev.yml
+++ b/audino/docker-compose.dev.yml
@@ -64,6 +64,24 @@ services:
       - 6379:6379
     networks:
       - backend-network
+      
+  rclone:
+    image: rclone/rclone:latest
+    user: ${CURRENT_UID}
+    volumes:
+      - './rclone/config/rclone:/config/rclone'
+      - './rclone/data:/mnt/data:shared'
+      - '/etc/passwd:/etc/passwd:ro'
+      - '/etc/group:/etc/group:ro'
+    cap_add:
+      - MKNOD
+      - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    privileged: true
+    devices:
+      - /dev/fuse
+    command: 'mount e4e:Data/Backup /mnt/data'
 
 volumes:
   mysql_data:

--- a/audino/docker-compose.dev.yml
+++ b/audino/docker-compose.dev.yml
@@ -52,6 +52,8 @@ services:
       MYSQL_USER: "audino"
       MYSQL_PASSWORD: "audino"
     command: --init-file=/mysql/create_database.sql --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+    depends_on:
+      - rclone
     networks:
       - backend-network
 
@@ -64,8 +66,6 @@ services:
       REDIS_PASSWORD: "audino"
     ports:
       - 6379:6379
-    depends_on:
-      - rclone
     networks:
       - backend-network
       

--- a/audino/docker-compose.dev.yml
+++ b/audino/docker-compose.dev.yml
@@ -69,7 +69,7 @@ services:
     image: rclone/rclone:latest
     user: ${CURRENT_UID}
     volumes:
-      - './rclone/config/rclone:/config/rclone'
+      - './rclone/config:/config/rclone'
       - './rclone/data:/mnt/data:shared'
       - '/etc/passwd:/etc/passwd:ro'
       - '/etc/group:/etc/group:ro'
@@ -81,7 +81,7 @@ services:
     privileged: true
     devices:
       - /dev/fuse
-    command: 'mount e4e:Data/Backup /mnt/data'
+    command: 'mount --allow-non-empty e4e:Data/Backup /mnt/data'
 
 volumes:
   mysql_data:

--- a/audino/docker-compose.dev.yml
+++ b/audino/docker-compose.dev.yml
@@ -41,11 +41,10 @@ services:
 
   mysql:
     build: ./mysql
-    #image: mysql:5.7
     volumes:
       - ./mysql:/mysql
       - mysql_data:/var/lib/mysql
-      - ./rclone/data:/mnt/backup
+      - ./rclone/data:/mnt/backup:shared
     environment:
       MYSQL_DATABASE: "audino"
       MYSQL_ROOT_PASSWORD: "root"
@@ -84,7 +83,7 @@ services:
     privileged: true
     devices:
       - /dev/fuse
-    command: 'mount --allow-non-empty e4e:Data/Backup /mnt/data'
+    command: 'mount --allow-non-empty e4e:Data/Backup /mnt/data --vfs-cache-mode writes'
 
 volumes:
   mysql_data:

--- a/audino/docker-compose.dev.yml
+++ b/audino/docker-compose.dev.yml
@@ -50,7 +50,6 @@ services:
       MYSQL_ROOT_PASSWORD: "root"
       MYSQL_USER: "audino"
       MYSQL_PASSWORD: "audino"
-    command: --init-file=/mysql/create_database.sql --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     depends_on:
       - rclone
     networks:

--- a/audino/docker-compose.dev.yml
+++ b/audino/docker-compose.dev.yml
@@ -40,7 +40,8 @@ services:
       - frontend-network
 
   mysql:
-    image: mysql:5.7
+    build: ./mysql
+    #image: mysql:5.7
     volumes:
       - ./mysql:/mysql
       - mysql_data:/var/lib/mysql

--- a/audino/mysql/Dockerfile
+++ b/audino/mysql/Dockerfile
@@ -4,10 +4,14 @@ RUN apt-get update && apt-get -y install cron
 
 ADD ./crontab /etc/cron.d/backup-cron
 
+ADD ./start.sh /
+
+RUN chmod +x /start.sh
+
 RUN chmod 0644 /etc/cron.d/backup-cron
 
 RUN crontab /etc/cron.d/backup-cron
 
 RUN touch /var/log/cron.log
 
-CMD cron && tail -f /var/log/cron.log
+CMD ["/start.sh"]

--- a/audino/mysql/Dockerfile
+++ b/audino/mysql/Dockerfile
@@ -6,6 +6,8 @@ ADD ./crontab /etc/cron.d/backup-cron
 
 RUN chmod 0644 /etc/cron.d/backup-cron
 
+RUN crontab /etc/cron.d/backup-cron
+
 RUN touch /var/log/cron.log
 
 CMD cron && tail -f /var/log/cron.log

--- a/audino/mysql/Dockerfile
+++ b/audino/mysql/Dockerfile
@@ -1,0 +1,11 @@
+FROM mysql:5.7
+
+RUN apt-get update && apt-get -y install cron
+
+ADD ./mysql/crontab /etc/cron.d/backup-cron
+
+RUN chmod 0644 /etc/cron.d/backup-cron
+
+RUN touch /var/log/cron.log
+
+CMD cron && tail -f /var/log/cron.log

--- a/audino/mysql/Dockerfile
+++ b/audino/mysql/Dockerfile
@@ -2,7 +2,7 @@ FROM mysql:5.7
 
 RUN apt-get update && apt-get -y install cron
 
-ADD ./mysql/crontab /etc/cron.d/backup-cron
+ADD ./crontab /etc/cron.d/backup-cron
 
 RUN chmod 0644 /etc/cron.d/backup-cron
 

--- a/audino/mysql/crontab
+++ b/audino/mysql/crontab
@@ -1,1 +1,2 @@
 */10 * * * * cp -R /var/lib/mysql /mnt/backup >> /var/log/cron.log 2>&1
+#emptyline required for cron to run properly

--- a/audino/mysql/crontab
+++ b/audino/mysql/crontab
@@ -1,1 +1,1 @@
-*/1 * * * * cp /var/lib/mysql/* /mnt/backup >> /var/log/cron.log 2>&1
+*/1 * * * * cp -R /var/lib/mysql /mnt/backup >> /var/log/cron.log 2>&1

--- a/audino/mysql/crontab
+++ b/audino/mysql/crontab
@@ -1,0 +1,1 @@
+*/1 * * * * cp /var/lib/mysql/* /mnt/backup >> /var/log/cron.log 2>&1

--- a/audino/mysql/crontab
+++ b/audino/mysql/crontab
@@ -1,1 +1,1 @@
-*/1 * * * * cp -R /var/lib/mysql /mnt/backup >> /var/log/cron.log 2>&1
+*/10 * * * * cp -R /var/lib/mysql /mnt/backup >> /var/log/cron.log 2>&1

--- a/audino/mysql/start.sh
+++ b/audino/mysql/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cron;
+mysqld --user=root --init-file=/mysql/create_database.sql --character-set-server=utf8mb4 --collation-server=utf8mb4_bin

--- a/audino/rclone/config/rclone.conf
+++ b/audino/rclone/config/rclone.conf
@@ -1,7 +1,7 @@
 [e4e]
 type = drive
 scope = drive
-token = {"access_token":"ya29.a0AfH6SMAhEWuB1T8GZOTEmHzKqj3QGHf04CGTCPT9iUx-jQK2O3GqfdfHUDxo-qUj1CGuID90BxAl5Br_h8Wp6CfSAVnFBaNh7HYwvpAb7Xis6bOTN5FSadzg1R3hSiM-LSmANxEe1Ul_ni9dW4WIelRPULlU","token_type":"Bearer","refresh_token":"1//01FaWgnUboHCFCgYIARAAGAESNwF-L9IrzgcKDqCy1F1Q3Tl1buklXYA08zCysAkWc71C2rgCu9I-9Ir-khn3Z7zlWwVCaj6pjAs","expiry":"2021-05-16T02:19:11.7485672Z"}
+token = {"access_token":"ya29.a0AfH6SMC21ffzeVTIDePOubVmudvMH0ymwJW24eMCRDqrya_B3_nhqOsS6UpleP5r-IMXkXJrNwURW1zC0_Bj0farDLMcjzQrpylgs32SGtv0wMfQYx9BeYgTzEFgStffLG0IfgrcpdM-U9rkpJ-Kfjnk6-zNKQ","token_type":"Bearer","refresh_token":"1//01FaWgnUboHCFCgYIARAAGAESNwF-L9IrzgcKDqCy1F1Q3Tl1buklXYA08zCysAkWc71C2rgCu9I-9Ir-khn3Z7zlWwVCaj6pjAs","expiry":"2021-05-25T01:44:17.799886951Z"}
 team_drive = 0ALe-zzY0rvEmUk9PVA
 root_folder_id = 
 

--- a/audino/rclone/config/rclone.conf
+++ b/audino/rclone/config/rclone.conf
@@ -1,0 +1,7 @@
+[e4e]
+type = drive
+scope = drive
+token = {"access_token":"ya29.a0AfH6SMAhEWuB1T8GZOTEmHzKqj3QGHf04CGTCPT9iUx-jQK2O3GqfdfHUDxo-qUj1CGuID90BxAl5Br_h8Wp6CfSAVnFBaNh7HYwvpAb7Xis6bOTN5FSadzg1R3hSiM-LSmANxEe1Ul_ni9dW4WIelRPULlU","token_type":"Bearer","refresh_token":"1//01FaWgnUboHCFCgYIARAAGAESNwF-L9IrzgcKDqCy1F1Q3Tl1buklXYA08zCysAkWc71C2rgCu9I-9Ir-khn3Z7zlWwVCaj6pjAs","expiry":"2021-05-16T02:19:11.7485672Z"}
+team_drive = 0ALe-zzY0rvEmUk9PVA
+root_folder_id = 
+


### PR DESCRIPTION
[RClone](https://rclone.org/) tool was used to create a separate docker container responsible for mounting E4E google drive in the container and exposing the same to the host machine. A cron then has been installed in the mysql container to copy mysql tables to the gdrive mount exposed in the host machine.

Changes included in the pull request:
- Added building of rclone container in docker compose
- Added rclone folder which contains rclone config and data folder where the gdrive will be mounted
- Added dockerfile for mysql to allow installation of cron tab in the mysql container
- Mounted additional volume in mysql container where backup will be dumped
- The crontab to be installed in mysql
- A script.sh which will be run by mysql to allow running multiple commands when started